### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ alembic-offline
 .. image:: https://api.travis-ci.org/paylogic/alembic-offline.png
    :target: https://travis-ci.org/paylogic/alembic-offline
 
-.. image:: https://pypip.in/v/alembic-offline/badge.png
+.. image:: https://img.shields.io/pypi/v/alembic-offline.svg
    :target: https://crate.io/packages/alembic-offline/
 
 .. image:: https://coveralls.io/repos/paylogic/alembic-offline/badge.svg?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20alembic-offline))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `alembic-offline`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.